### PR TITLE
Add support for polkadot.js api call serialization

### DIFF
--- a/src/nodes/ParachainNode.ts
+++ b/src/nodes/ParachainNode.ts
@@ -10,7 +10,8 @@ import {
   TScenario,
   IXTokensTransfer,
   IPolkadotXCMTransfer,
-  Version
+  Version,
+  TSerializedApiCall
 } from '../types'
 import {
   handleAddress,
@@ -69,8 +70,9 @@ abstract class ParachainNode {
     currencyId: number | undefined,
     amount: any,
     to: string,
-    destination?: TNode
-  ): Extrinsic {
+    destination?: TNode,
+    serializedApiCallEnabled = false
+  ): Extrinsic | TSerializedApiCall {
     const scenario: TScenario = destination ? 'ParaToPara' : 'ParaToRelay'
     const paraId = destination ? getParaId(destination) : undefined
 
@@ -81,7 +83,8 @@ abstract class ParachainNode {
         currencyID: currencyId,
         amount,
         addressSelection: handleAddress(scenario, 'xTokens', api, to, this.version, paraId),
-        fees: getFees(scenario)
+        fees: getFees(scenario),
+        serializedApiCallEnabled
       })
     } else if (supportsPolkadotXCM(this)) {
       return this.transferPolkadotXCM({
@@ -95,7 +98,8 @@ abstract class ParachainNode {
           this._node,
           currencyId
         ),
-        scenario
+        scenario,
+        serializedApiCallEnabled
       })
     } else {
       throw new NoXCMSupportImplementedError(this._node)

--- a/src/nodes/PolkadotXCMTransferImpl.ts
+++ b/src/nodes/PolkadotXCMTransferImpl.ts
@@ -1,13 +1,28 @@
 // Contains basic structure of polkadotXCM call
 
-import { Extrinsic, PolkadotXCMTransferInput } from '../types'
+import { Extrinsic, PolkadotXCMTransferInput, TSerializedApiCall, TType } from '../types'
 
 class PolkadotXCMTransferImpl {
   static transferPolkadotXCM(
-    { api, header, addressSelection, currencySelection }: PolkadotXCMTransferInput,
+    {
+      api,
+      header,
+      addressSelection,
+      currencySelection,
+      serializedApiCallEnabled
+    }: PolkadotXCMTransferInput,
     method: string,
     fees: 'Unlimited' | undefined = undefined
-  ): Extrinsic {
+  ): Extrinsic | TSerializedApiCall {
+    if (serializedApiCallEnabled) {
+      return {
+        type: TType.TX,
+        module: 'polkadotXcm',
+        section: method,
+        parameters: [header, addressSelection, currencySelection, 0, ...(fees ? [fees] : [])]
+      }
+    }
+
     return fees
       ? api.tx.polkadotXcm[method](header, addressSelection, currencySelection, 0, fees)
       : api.tx.polkadotXcm[method](header, addressSelection, currencySelection, 0)

--- a/src/nodes/XTokensTransferImpl.ts
+++ b/src/nodes/XTokensTransferImpl.ts
@@ -1,21 +1,27 @@
 // Contains basic structure of xToken call
 
-import { Extrinsic, TPallet, XTokensTransferInput } from '../types'
+import { Extrinsic, TPallet, TSerializedApiCall, TType, XTokensTransferInput } from '../types'
 import { lowercaseFirstLetter } from '../utils'
 
 class XTokensTransferImpl {
   static transferXTokens(
-    { api, amount, addressSelection }: XTokensTransferInput,
+    { api, amount, addressSelection, serializedApiCallEnabled }: XTokensTransferInput,
     currencySelection: any,
     fees: string | number = 'Unlimited',
     pallet: TPallet = 'XTokens'
-  ): Extrinsic {
-    return api.tx[lowercaseFirstLetter(pallet.toString())].transfer(
-      currencySelection,
-      amount,
-      addressSelection,
-      fees
-    )
+  ): Extrinsic | TSerializedApiCall {
+    const module = lowercaseFirstLetter(pallet.toString())
+
+    if (serializedApiCallEnabled) {
+      return {
+        type: TType.TX,
+        module,
+        section: 'transfer',
+        parameters: [currencySelection, amount, addressSelection, fees]
+      }
+    }
+
+    return api.tx[module].transfer(currencySelection, amount, addressSelection, fees)
   }
 }
 

--- a/src/nodes/supported/Basilisk.ts
+++ b/src/nodes/supported/Basilisk.ts
@@ -10,7 +10,7 @@ class Basilisk extends ParachainNode implements IXTokensTransfer {
   }
 
   transferXTokens(input: XTokensTransferInput) {
-    const { currencyID, fees } = input
+    const { currencyID } = input
     return XTokensTransferImpl.transferXTokens(input, currencyID)
   }
 }

--- a/src/pallets/builder/builders/Builder.test.ts
+++ b/src/pallets/builder/builders/Builder.test.ts
@@ -1,4 +1,4 @@
-//Contains builder pattern tests for different Builder pattern functionalities
+// Contains builder pattern tests for different Builder pattern functionalities
 
 import { ApiPromise } from '@polkadot/api'
 import { vi, describe, expect, it, beforeEach } from 'vitest'
@@ -29,7 +29,7 @@ describe('Builder', () => {
     api = await createApiInstance(WS_URL)
   })
 
-  it('should initiatie a para to para transfer with currency symbol', async () => {
+  it('should initiatie a para to para transfer with currency symbol', () => {
     const spy = vi.spyOn(xcmPallet, 'send').mockImplementation(() => {
       return undefined as any
     })
@@ -39,7 +39,7 @@ describe('Builder', () => {
     expect(spy).toHaveBeenCalledWith(api, NODE, CURRENCY, AMOUNT, ADDRESS, NODE_2)
   })
 
-  it('should initiatie a para to para transfer with currency id', async () => {
+  it('should initiatie a para to para transfer with currency id', () => {
     const spy = vi.spyOn(xcmPallet, 'send').mockImplementation(() => {
       return undefined as any
     })
@@ -49,7 +49,7 @@ describe('Builder', () => {
     expect(spy).toHaveBeenCalledWith(api, NODE, CURRENCY_ID, AMOUNT, ADDRESS, NODE_2)
   })
 
-  it('should initiatie a relay to para transfer', async () => {
+  it('should initiatie a relay to para transfer', () => {
     const spy = vi.spyOn(xcmPallet, 'transferRelayToPara').mockImplementation(() => {
       return undefined as any
     })
@@ -59,7 +59,7 @@ describe('Builder', () => {
     expect(spy).toHaveBeenCalledWith(api, NODE, AMOUNT, ADDRESS)
   })
 
-  it('should initiatie a para to relay transfer with currency symbol', async () => {
+  it('should initiatie a para to relay transfer with currency symbol', () => {
     const spy = vi.spyOn(xcmPallet, 'send').mockImplementation(() => {
       return undefined as any
     })
@@ -69,7 +69,7 @@ describe('Builder', () => {
     expect(spy).toHaveBeenCalledWith(api, NODE, CURRENCY, AMOUNT, ADDRESS, undefined)
   })
 
-  it('should initiatie a para to relay transfer with currency id', async () => {
+  it('should initiatie a para to relay transfer with currency id', () => {
     const spy = vi.spyOn(xcmPallet, 'send').mockImplementation(() => {
       return undefined as any
     })
@@ -79,7 +79,7 @@ describe('Builder', () => {
     expect(spy).toHaveBeenCalledWith(api, NODE, CURRENCY_ID, AMOUNT, ADDRESS, undefined)
   })
 
-  it('should open a channel', async () => {
+  it('should open a channel', () => {
     const spy = vi.spyOn(parasSudoWrapper, 'openChannel').mockImplementation(() => {
       return undefined as any
     })
@@ -95,7 +95,7 @@ describe('Builder', () => {
     expect(spy).toHaveBeenCalledWith(api, NODE, NODE_2, CHANNEL_MAX_SIZE, CHANNEL_MAX_MSG_SIZE)
   })
 
-  it('should close a channel', async () => {
+  it('should close a channel', () => {
     const spy = vi.spyOn(hrmp, 'closeChannel').mockImplementation(() => {
       return undefined as any
     })
@@ -110,7 +110,7 @@ describe('Builder', () => {
     expect(spy).toHaveBeenCalledWith(api, NODE, CHANNEL_INBOUND, CHANNEL_OUTBOUND)
   })
 
-  it('should add liquidity', async () => {
+  it('should add liquidity', () => {
     const spy = vi.spyOn(xyk, 'addLiquidity').mockImplementation(() => {
       return undefined as any
     })
@@ -131,7 +131,7 @@ describe('Builder', () => {
     expect(spy).toHaveBeenCalledWith(api, ASSET_A, ASSET_B, AMOUNT_A, AMOUNT_B_MAX_LIMIT)
   })
 
-  it('should remove liquidity', async () => {
+  it('should remove liquidity', () => {
     const spy = vi.spyOn(xyk, 'removeLiquidity').mockImplementation(() => {
       return undefined as any
     })
@@ -150,7 +150,7 @@ describe('Builder', () => {
     expect(spy).toHaveBeenCalledWith(api, ASSET_A, ASSET_B, LIQUIDITY_AMOUNT)
   })
 
-  it('should buy', async () => {
+  it('should buy', () => {
     const spy = vi.spyOn(xyk, 'buy').mockImplementation(() => {
       return undefined as any
     })
@@ -173,7 +173,7 @@ describe('Builder', () => {
     expect(spy).toHaveBeenCalledWith(api, ASSET_OUT, ASSET_IN, AMOUNT, MAX_LIMIT, DISCOUNT)
   })
 
-  it('should sell', async () => {
+  it('should sell', () => {
     const spy = vi.spyOn(xyk, 'sell').mockImplementation(() => {
       return undefined as any
     })
@@ -196,7 +196,7 @@ describe('Builder', () => {
     expect(spy).toHaveBeenCalledWith(api, ASSET_IN, ASSET_OUT, AMOUNT, MAX_LIMIT, DISCOUNT)
   })
 
-  it('should create pool', async () => {
+  it('should create pool', () => {
     const spy = vi.spyOn(xyk, 'createPool').mockImplementation(() => {
       return undefined as any
     })
@@ -215,5 +215,24 @@ describe('Builder', () => {
       .build()
 
     expect(spy).toHaveBeenCalledWith(api, ASSET_A, AMOUNT_A, ASSET_B, AMOUNT_B)
+  })
+
+  it('should request a para to para transfer serialized api call with currency id', () => {
+    const serializedApiCall = Builder(api)
+      .from(NODE)
+      .to(NODE_2)
+      .currency('DOT')
+      .amount(AMOUNT)
+      .address(ADDRESS)
+      .buildSerializedApiCall()
+
+    expect(serializedApiCall).toHaveProperty('type')
+    expect(serializedApiCall).toHaveProperty('module')
+    expect(serializedApiCall).toHaveProperty('section')
+    expect(serializedApiCall).toHaveProperty('parameters')
+    expect(serializedApiCall.type).toBeTypeOf('string')
+    expect(serializedApiCall.module).toBeTypeOf('string')
+    expect(serializedApiCall.section).toBeTypeOf('string')
+    expect(Array.isArray(serializedApiCall.parameters)).toBe(true)
   })
 })

--- a/src/pallets/builder/builders/SendBuilder.ts
+++ b/src/pallets/builder/builders/SendBuilder.ts
@@ -1,11 +1,12 @@
 // Implements builder pattern for XCM message creation operations operation
 
 import { ApiPromise } from '@polkadot/api'
-import { send } from '../../xcmPallet'
-import { Extrinsic, TNode } from '../../../types'
+import { send, sendSerializedApiCall } from '../../xcmPallet'
+import { Extrinsic, TNode, TSerializedApiCall } from '../../../types'
 
 export interface FinalRelayToParaBuilder {
   build(): Extrinsic | never
+  buildSerializedApiCall(): TSerializedApiCall
 }
 
 export interface AddressSendBuilder {
@@ -66,6 +67,17 @@ class SendBuilder implements AmountSendBuilder, AddressSendBuilder, FinalRelayTo
 
   build() {
     return send(this.api, this.from, this.currency, this._amount, this._address, this.to)
+  }
+
+  buildSerializedApiCall() {
+    return sendSerializedApiCall(
+      this.api,
+      this.from,
+      this.currency,
+      this._amount,
+      this._address,
+      this.to
+    )
   }
 }
 

--- a/src/pallets/xcmPallet/transfer.ts
+++ b/src/pallets/xcmPallet/transfer.ts
@@ -1,7 +1,7 @@
 // Contains basic call formatting for different XCM Palletss
 
 import type { ApiPromise } from '@polkadot/api'
-import { Extrinsic, TNode, Version } from '../../types'
+import { Extrinsic, TNode, TSerializedApiCall, Version } from '../../types'
 import {
   handleAddress,
   createHeaderPolkadotXCM,
@@ -13,14 +13,15 @@ import { getAssetBySymbolOrId } from '../assets/assetsUtils'
 import { InvalidCurrencyError } from '../../errors/InvalidCurrencyError'
 import { NodeNotSupportedError } from '../../errors/NodeNotSupportedError'
 
-export function send(
+const sendCommon = (
   api: ApiPromise,
   origin: TNode,
   currencySymbolOrId: string | number | bigint,
   amount: any,
   to: string,
-  destination?: TNode
-): Extrinsic {
+  destination?: TNode,
+  serializedApiCallEnabled = false
+): Extrinsic | TSerializedApiCall => {
   const asset = getAssetBySymbolOrId(origin, currencySymbolOrId.toString())
 
   if (!asset) {
@@ -36,7 +37,45 @@ export function send(
   }
   const { symbol: currencySymbol, assetId: currencyId } = asset
 
-  return getNode(origin).transfer(api, currencySymbol, currencyId, amount, to, destination)
+  return getNode(origin).transfer(
+    api,
+    currencySymbol,
+    currencyId,
+    amount,
+    to,
+    destination,
+    serializedApiCallEnabled
+  )
+}
+
+export const sendSerializedApiCall = (
+  api: ApiPromise,
+  origin: TNode,
+  currencySymbolOrId: string | number | bigint,
+  amount: any,
+  to: string,
+  destination?: TNode
+): TSerializedApiCall => {
+  return sendCommon(
+    api,
+    origin,
+    currencySymbolOrId,
+    amount,
+    to,
+    destination,
+    true
+  ) as TSerializedApiCall
+}
+
+export function send(
+  api: ApiPromise,
+  origin: TNode,
+  currencySymbolOrId: string | number | bigint,
+  amount: any,
+  to: string,
+  destination?: TNode
+): Extrinsic {
+  return sendCommon(api, origin, currencySymbolOrId, amount, to, destination) as Extrinsic
 }
 
 export function transferRelayToPara(

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,6 +35,19 @@ export type TPalletMap = {
 }
 export type TPalletJsonMap = Record<TNode, TPalletMap>
 
+export enum TType {
+  CONSTS = 'consts',
+  QUERY = 'query',
+  TX = 'tx'
+}
+
+export type TSerializedApiCall = {
+  type: TType
+  module: string
+  section: string
+  parameters: any[]
+}
+
 export type XTokensTransferInput = {
   api: ApiPromise
   currency: string
@@ -42,10 +55,11 @@ export type XTokensTransferInput = {
   amount: any
   addressSelection: any
   fees: number
+  serializedApiCallEnabled?: boolean
 }
 
 export interface IXTokensTransfer {
-  transferXTokens(input: XTokensTransferInput): Extrinsic
+  transferXTokens(input: XTokensTransferInput): Extrinsic | TSerializedApiCall
 }
 
 export type PolkadotXCMTransferInput = {
@@ -54,10 +68,11 @@ export type PolkadotXCMTransferInput = {
   addressSelection: any
   currencySelection: any
   scenario: TScenario
+  serializedApiCallEnabled?: boolean
 }
 
 export interface IPolkadotXCMTransfer {
-  transferPolkadotXCM(input: PolkadotXCMTransferInput): Extrinsic
+  transferPolkadotXCM(input: PolkadotXCMTransferInput): Extrinsic | TSerializedApiCall
 }
 
 export enum Version {


### PR DESCRIPTION
Due to development of LightSpell XCM API we need to add support for call serialization (Not breaking change)