### PR TITLE
Remove unnecessary currency() method from ParaToRelay builder.

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Builder(api).from(NODE).to(NODE).currency(CurrencyString||CurrencyID).amount(amo
 Builder(api).to(NODE).amount(amount).address(address).build()
 
 //Transfer tokens from Parachain to Relay chain
-Builder(api).from(NODE).currency(CurrencyString||CurrencyID).amount(amount).address(address).build()
+Builder(api).from(NODE).amount(amount).address(address).build()
 
 //Close HRMP channels
 Builder(api).from(NODE).closeChannel().inbound(inbound).outbound(outbound).build()
@@ -130,7 +130,7 @@ Function pattern XCM & HRMP construction
 paraspell.xcmPallet.send(api: ApiPromise, origin: origin  Parachain  name  string, currency: CurrencyString||CurrencyID, amount: any, to: destination  address  string, destination: destination  Parachain  ID)
 
 //Transfer tokens from Parachain to Relay chain
-paraspell.xcmPallet.send(api: ApiPromise, origin: origin  Parachain  name  string, currency: CurrencyString||CurrencyID, amount: any, to: destination  address  string)
+paraspell.xcmPallet.send(api: ApiPromise, origin: origin  Parachain  name  string, amount: any, to: destination  address  string)
 
 //Transfer tokens from Relay chain to Parachain
 paraspell.xcmPallet.transferRelayToPara(api: ApiPromise, destination: destination  Parachain  ID, amount: any, to: destination  address  string)

--- a/docs/supportedNodes.md
+++ b/docs/supportedNodes.md
@@ -11,7 +11,7 @@
 | Node name | Website | Github | Polkadot.js |Node id | Supported XCM Pallet | Current latest XCM Version |
 | ------------- | ------------- | ------------- |------------- |------------- |------------- |------------- |
 | Statemint | [Website](https://www.parity.io/) |[Github](https://github.com/paritytech/cumulus)| [Polkadot.js](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fstatemint.api.onfinality.io%2Fpublic-ws#/explorer)|1000 | polkadotXCM | XCM V3 |
-| Acala | [Website](https://acala.network/) |[Github](https://github.com/AcalaNetwork/Acala)| [Polkadot.js](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2F1rpc.io%2Faca#/explorer)|2000 | xTokens |XCM V1 |
+| Acala | [Website](https://acala.network/) |[Github](https://github.com/AcalaNetwork/Acala)| [Polkadot.js](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2F1rpc.io%2Faca#/explorer)|2000 | xTokens |XCM V3 |
 | Astar | [Website](https://astar.network/) |[Github](https://github.com/AstarNetwork/Astar)| [Polkadot.js](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fastar-rpc.dwellir.com#/explorer)|2006 | polkadotXCM |XCM V3 |
 | BifrostPolkadot | [Website](https://thebifrost.io/) |[Github](https://github.com/bifrost-finance/bifrost)| [Polkadot.js](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fhk.p.bifrost-rpc.liebi.com%2Fws#/explorer)| 2030| xTokens |XCM V3 |
 | Centrifuge | [Website](https://centrifuge.io/) |[Github](https://github.com/centrifuge/centrifuge-chain)| [Polkadot.js](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fcentrifuge-rpc.dwellir.com#/explorer)|2031 | xTokens |XCM V1 |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraspell/sdk",
-  "version": "1.1.15",
+  "version": "2.0.0",
   "description": "SDK for ParaSpell XCM/XCMP tool for developers",
   "repository": "@paraspell/sdk",
   "license": "MIT",

--- a/src/nodes/supported/Acala.ts
+++ b/src/nodes/supported/Acala.ts
@@ -6,7 +6,7 @@ import XTokensTransferImpl from '../XTokensTransferImpl'
 
 class Acala extends ParachainNode implements IXTokensTransfer {
   constructor() {
-    super('Acala', 'acala', 'polkadot', Version.V1)
+    super('Acala', 'acala', 'polkadot', Version.V3)
   }
 
   transferXTokens(input: XTokensTransferInput) {

--- a/src/pallets/assets/assets.ts
+++ b/src/pallets/assets/assets.ts
@@ -1,4 +1,4 @@
-//Contains different useful asset query operations from compatible Parachains asset map
+// Contains different useful asset query operations from compatible Parachains asset map
 
 import * as assetsMapJson from '../../maps/assets.json' assert { type: 'json' }
 import { NODE_NAMES } from '../../maps/consts'
@@ -60,8 +60,7 @@ export function getParaId(node: TNode) {
 }
 
 export function getTNode(nodeID: number) {
-  for (const node of NODE_NAMES){
-  if( getParaId(node) === nodeID )
-    return node
+  for (const node of NODE_NAMES) {
+    if (getParaId(node) === nodeID) return node
   }
 }

--- a/src/pallets/builder/builders/Builder.test.ts
+++ b/src/pallets/builder/builders/Builder.test.ts
@@ -8,6 +8,7 @@ import * as hrmp from '../../hrmp'
 import * as parasSudoWrapper from '../../parasSudoWrapper'
 import * as xcmPallet from '../../xcmPallet'
 import * as xyk from '../../xyk'
+import { getRelayChainSymbol } from '../../assets'
 import { Builder } from './Builder'
 
 const WS_URL = 'wss://para.f3joule.space'
@@ -64,19 +65,11 @@ describe('Builder', () => {
       return undefined as any
     })
 
-    Builder(api).from(NODE).currency(CURRENCY).amount(AMOUNT).address(ADDRESS).build()
+    const currency = getRelayChainSymbol(NODE)
 
-    expect(spy).toHaveBeenCalledWith(api, NODE, CURRENCY, AMOUNT, ADDRESS, undefined)
-  })
+    Builder(api).from(NODE).amount(AMOUNT).address(ADDRESS).build()
 
-  it('should initiatie a para to relay transfer with currency id', () => {
-    const spy = vi.spyOn(xcmPallet, 'send').mockImplementation(() => {
-      return undefined as any
-    })
-
-    Builder(api).from(NODE).currency(CURRENCY_ID).amount(AMOUNT).address(ADDRESS).build()
-
-    expect(spy).toHaveBeenCalledWith(api, NODE, CURRENCY_ID, AMOUNT, ADDRESS, undefined)
+    expect(spy).toHaveBeenCalledWith(api, NODE, currency, AMOUNT, ADDRESS)
   })
 
   it('should open a channel', () => {

--- a/src/pallets/builder/builders/Builder.ts
+++ b/src/pallets/builder/builders/Builder.ts
@@ -1,7 +1,7 @@
 // Implements general builder pattern, this is Builder main file
 
 import { ApiPromise } from '@polkadot/api'
-import { TNode } from '../../../types'
+import { Extrinsic, TNode, TSerializedApiCall } from '../../../types'
 import AddLiquidityBuilder from './AddLiquidityBuilder'
 import BuyBuilder from './BuyBuilder'
 import CloseChannelBuilder from './CloseChannelBuilder'
@@ -10,7 +10,8 @@ import OpenChannelBuilder from './OpenChannelBuilder'
 import RelayToParaBuilder from './RelayToParaBuilder'
 import RemoveLiquidityBuilder from './RemoveLiquidityBuilder'
 import SellBuilder from './SellBuilder'
-import SendBuilder from './SendBuilder'
+import ParaToParaBuilder from './ParaToParaBuilder'
+import ParaToRelayBuilder from './ParaToRelayBuilder'
 
 class ToGeneralBuilder {
   private api: ApiPromise
@@ -24,7 +25,7 @@ class ToGeneralBuilder {
   }
 
   currency(currency: string | number | bigint) {
-    return SendBuilder.createParaToPara(this.api, this.from, this.to, currency)
+    return ParaToParaBuilder.createParaToPara(this.api, this.from, this.to, currency)
   }
 
   openChannel() {
@@ -45,8 +46,8 @@ class FromGeneralBuilder {
     return new ToGeneralBuilder(this.api, this.from, node)
   }
 
-  currency(currency: string | number | bigint) {
-    return SendBuilder.createParaToRelay(this.api, this.from, currency)
+  amount(amount: any) {
+    return ParaToRelayBuilder.create(this.api, this.from, amount)
   }
 
   closeChannel() {
@@ -92,4 +93,17 @@ class GeneralBuilder {
 
 export function Builder(api: ApiPromise) {
   return new GeneralBuilder(api)
+}
+
+export interface FinalBuilder {
+  build(): Extrinsic | never
+  buildSerializedApiCall(): TSerializedApiCall
+}
+
+export interface AddressBuilder {
+  address(address: string): FinalBuilder
+}
+
+export interface AmountBuilder {
+  amount(amount: any): AddressBuilder
 }

--- a/src/pallets/builder/builders/CloseChannelBuilder.ts
+++ b/src/pallets/builder/builders/CloseChannelBuilder.ts
@@ -1,4 +1,4 @@
-//Implements builder pattern for Close HRMP channel operation 
+// Implements builder pattern for Close HRMP channel operation
 
 import { ApiPromise } from '@polkadot/api'
 import { Extrinsic, TNode } from '../../../types'

--- a/src/pallets/builder/builders/OpenChannelBuilder.ts
+++ b/src/pallets/builder/builders/OpenChannelBuilder.ts
@@ -1,4 +1,4 @@
-//Implements builder pattern for Open HRMP channel operation 
+// Implements builder pattern for Open HRMP channel operation
 
 import { ApiPromise } from '@polkadot/api'
 import { Extrinsic, TNode } from '../../../types'

--- a/src/pallets/builder/builders/ParaToParaBuilder.ts
+++ b/src/pallets/builder/builders/ParaToParaBuilder.ts
@@ -2,48 +2,23 @@
 
 import { ApiPromise } from '@polkadot/api'
 import { send, sendSerializedApiCall } from '../../xcmPallet'
-import { Extrinsic, TNode, TSerializedApiCall } from '../../../types'
+import { TNode } from '../../../types'
+import { AddressBuilder, AmountBuilder, FinalBuilder } from './Builder'
 
-export interface FinalRelayToParaBuilder {
-  build(): Extrinsic | never
-  buildSerializedApiCall(): TSerializedApiCall
-}
-
-export interface AddressSendBuilder {
-  address(address: string): FinalRelayToParaBuilder
-}
-
-export interface AmountSendBuilder {
-  amount(amount: any): AddressSendBuilder
-}
-
-class SendBuilder implements AmountSendBuilder, AddressSendBuilder, FinalRelayToParaBuilder {
+class ParaToParaBuilder implements AmountBuilder, AddressBuilder, FinalBuilder {
   private api: ApiPromise
   private from: TNode
-  private to: TNode | undefined
+  private to: TNode
   private currency: string | number | bigint
 
   private _amount: any
   private _address: string
 
-  private constructor(
-    api: ApiPromise,
-    from: TNode,
-    to: TNode | undefined,
-    currency: string | number | bigint
-  ) {
+  private constructor(api: ApiPromise, from: TNode, to: TNode, currency: string | number | bigint) {
     this.api = api
     this.from = from
     this.to = to
     this.currency = currency
-  }
-
-  static createParaToRelay(
-    api: ApiPromise,
-    from: TNode,
-    currency: string | number | bigint
-  ): AmountSendBuilder {
-    return new SendBuilder(api, from, undefined, currency)
   }
 
   static createParaToPara(
@@ -51,8 +26,8 @@ class SendBuilder implements AmountSendBuilder, AddressSendBuilder, FinalRelayTo
     from: TNode,
     to: TNode,
     currency: string | number | bigint
-  ): AmountSendBuilder {
-    return new SendBuilder(api, from, to, currency)
+  ): AmountBuilder {
+    return new ParaToParaBuilder(api, from, to, currency)
   }
 
   amount(amount: any) {
@@ -81,4 +56,4 @@ class SendBuilder implements AmountSendBuilder, AddressSendBuilder, FinalRelayTo
   }
 }
 
-export default SendBuilder
+export default ParaToParaBuilder

--- a/src/pallets/builder/builders/ParaToRelayBuilder.ts
+++ b/src/pallets/builder/builders/ParaToRelayBuilder.ts
@@ -1,0 +1,42 @@
+// Implements builder pattern for XCM message creation operations operation
+
+import { ApiPromise } from '@polkadot/api'
+import { send, sendSerializedApiCall } from '../../xcmPallet'
+import { TNode } from '../../../types'
+import { getRelayChainSymbol } from '../../assets'
+import { AddressBuilder, FinalBuilder } from './Builder'
+
+class ParaToRelayBuilder implements AddressBuilder, FinalBuilder {
+  private api: ApiPromise
+  private from: TNode
+  private amount: any
+
+  private _address: string
+
+  private constructor(api: ApiPromise, from: TNode, amount: any) {
+    this.api = api
+    this.from = from
+    this.amount = amount
+  }
+
+  static create(api: ApiPromise, from: TNode, amount: any): AddressBuilder {
+    return new ParaToRelayBuilder(api, from, amount)
+  }
+
+  address(address: string) {
+    this._address = address
+    return this
+  }
+
+  build() {
+    const currency = getRelayChainSymbol(this.from)
+    return send(this.api, this.from, currency, this.amount, this._address)
+  }
+
+  buildSerializedApiCall() {
+    const currency = getRelayChainSymbol(this.from)
+    return sendSerializedApiCall(this.api, this.from, currency, this.amount, this._address)
+  }
+}
+
+export default ParaToRelayBuilder

--- a/src/pallets/builder/builders/RelayToParaBuilder.ts
+++ b/src/pallets/builder/builders/RelayToParaBuilder.ts
@@ -2,24 +2,10 @@
 
 import { ApiPromise } from '@polkadot/api'
 import { transferRelayToPara, transferRelayToParaSerializedApiCall } from '../../xcmPallet'
-import { Extrinsic, TNode, TSerializedApiCall } from '../../../types'
+import { TNode } from '../../../types'
+import { AddressBuilder, AmountBuilder, FinalBuilder } from './Builder'
 
-export interface FinalRelayToParaBuilder {
-  build(): Extrinsic | never
-  buildSerializedApiCall(): TSerializedApiCall
-}
-
-export interface AddressRelayToParaBuilder {
-  address(address: string): FinalRelayToParaBuilder
-}
-
-export interface AmountRelayToParaBuilder {
-  amount(amount: number): AddressRelayToParaBuilder
-}
-
-class RelayToParaBuilder
-  implements AmountRelayToParaBuilder, AddressRelayToParaBuilder, FinalRelayToParaBuilder
-{
+class RelayToParaBuilder implements AmountBuilder, AddressBuilder, FinalBuilder {
   private api: ApiPromise
   private to: TNode
 
@@ -31,7 +17,7 @@ class RelayToParaBuilder
     this.to = to
   }
 
-  static create(api: ApiPromise, to: TNode): AmountRelayToParaBuilder {
+  static create(api: ApiPromise, to: TNode): AmountBuilder {
     return new RelayToParaBuilder(api, to)
   }
 


### PR DESCRIPTION
This PR removes the need to input currency in the Para to Relay scenario and bumps SDK to v 2.0 which is fully API-ready.