### PR TITLE
Fix a bug when KSM assetId exists but is not found

### DIFF
--- a/src/pallets/assets/assetsUtils.test.ts
+++ b/src/pallets/assets/assetsUtils.test.ts
@@ -1,4 +1,4 @@
-//Contains tests for different Asset queries used in XCM call creation
+// Contains tests for different Asset queries used in XCM call creation
 
 import { describe, expect, it } from 'vitest'
 import { NODE_NAMES } from '../../maps/consts'
@@ -61,5 +61,11 @@ describe('getAssetBySymbolOrId', () => {
       const asset = getAssetBySymbolOrId(node, relayChainAssetSymbol)
       expect(asset).toHaveProperty('symbol')
     })
+  })
+
+  it('should find assetId for KSM asset in Statemine', () => {
+    const asset = getAssetBySymbolOrId('Statemine', 'KSM')
+    expect(asset).toHaveProperty('symbol')
+    expect(asset).toHaveProperty('assetId')
   })
 })

--- a/src/pallets/assets/assetsUtils.ts
+++ b/src/pallets/assets/assetsUtils.ts
@@ -1,4 +1,4 @@
-//Contains function for getting Asset ID or Symbol used in XCM call creation
+// Contains function for getting Asset ID or Symbol used in XCM call creation
 
 import { TNode } from '../../types'
 import { getAssetsObject } from './assets'
@@ -9,7 +9,7 @@ export const getAssetBySymbolOrId = (
 ): { symbol: string; assetId?: number } | null => {
   const { otherAssets, nativeAssets, relayChainAssetSymbol } = getAssetsObject(node)
 
-  const asset = [...nativeAssets, ...otherAssets].find(
+  const asset = [...otherAssets, ...nativeAssets].find(
     ({ symbol, assetId }) => symbol === symbolOrId || assetId === symbolOrId
   )
 


### PR DESCRIPTION
This PR fixes bug with Statemine and Statemint Parachains where the KSM asset id was not assigned to the call.