### PR TITLE
Add XCM-API support for hrmp channels

### DIFF
--- a/src/pallets/builder/builders/Builder.test.ts
+++ b/src/pallets/builder/builders/Builder.test.ts
@@ -88,6 +88,23 @@ describe('Builder', () => {
     expect(spy).toHaveBeenCalledWith(api, NODE, NODE_2, CHANNEL_MAX_SIZE, CHANNEL_MAX_MSG_SIZE)
   })
 
+  it('should return a channel open serialized api call', () => {
+    const serializedApiCall = Builder(api)
+      .from(NODE)
+      .to(NODE_2)
+      .openChannel()
+      .maxSize(CHANNEL_MAX_SIZE)
+      .maxMessageSize(CHANNEL_MAX_MSG_SIZE)
+      .buildSerializedApiCall()
+
+    expect(serializedApiCall).toHaveProperty('module')
+    expect(serializedApiCall).toHaveProperty('section')
+    expect(serializedApiCall).toHaveProperty('parameters')
+    expect(serializedApiCall.module).toBeTypeOf('string')
+    expect(serializedApiCall.section).toBeTypeOf('string')
+    expect(Array.isArray(serializedApiCall.parameters)).toBe(true)
+  })
+
   it('should close a channel', () => {
     const spy = vi.spyOn(hrmp, 'closeChannel').mockImplementation(() => {
       return undefined as any
@@ -101,6 +118,22 @@ describe('Builder', () => {
       .build()
 
     expect(spy).toHaveBeenCalledWith(api, NODE, CHANNEL_INBOUND, CHANNEL_OUTBOUND)
+  })
+
+  it('should return a channel close serialized api call', () => {
+    const serializedApiCall = Builder(api)
+      .from(NODE)
+      .closeChannel()
+      .inbound(CHANNEL_INBOUND)
+      .outbound(CHANNEL_OUTBOUND)
+      .buildSerializedApiCall()
+
+    expect(serializedApiCall).toHaveProperty('module')
+    expect(serializedApiCall).toHaveProperty('section')
+    expect(serializedApiCall).toHaveProperty('parameters')
+    expect(serializedApiCall.module).toBeTypeOf('string')
+    expect(serializedApiCall.section).toBeTypeOf('string')
+    expect(Array.isArray(serializedApiCall.parameters)).toBe(true)
   })
 
   it('should add liquidity', () => {

--- a/src/pallets/builder/builders/CloseChannelBuilder.ts
+++ b/src/pallets/builder/builders/CloseChannelBuilder.ts
@@ -1,15 +1,12 @@
 // Implements builder pattern for Close HRMP channel operation
 
 import { ApiPromise } from '@polkadot/api'
-import { Extrinsic, TNode } from '../../../types'
-import { closeChannel } from '../../hrmp'
-
-export interface FinalCloseChannelBuilder {
-  build(): Extrinsic
-}
+import { TNode } from '../../../types'
+import { closeChannel, closeChannelSerializedApiCall } from '../../hrmp'
+import { FinalBuilder } from './Builder'
 
 export interface OutboundCloseChannelBuilder {
-  outbound(inbound: number): FinalCloseChannelBuilder
+  outbound(inbound: number): FinalBuilder
 }
 
 export interface InboundCloseChannelBuilder {
@@ -17,7 +14,7 @@ export interface InboundCloseChannelBuilder {
 }
 
 class CloseChannelBuilder
-  implements InboundCloseChannelBuilder, OutboundCloseChannelBuilder, FinalCloseChannelBuilder
+  implements InboundCloseChannelBuilder, OutboundCloseChannelBuilder, FinalBuilder
 {
   private api: ApiPromise
   private from: TNode
@@ -46,6 +43,10 @@ class CloseChannelBuilder
 
   build() {
     return closeChannel(this.api, this.from, this._inbound, this._outbound)
+  }
+
+  buildSerializedApiCall() {
+    return closeChannelSerializedApiCall(this.api, this.from, this._inbound, this._outbound)
   }
 }
 

--- a/src/pallets/builder/builders/OpenChannelBuilder.ts
+++ b/src/pallets/builder/builders/OpenChannelBuilder.ts
@@ -1,15 +1,12 @@
 // Implements builder pattern for Open HRMP channel operation
 
 import { ApiPromise } from '@polkadot/api'
-import { Extrinsic, TNode } from '../../../types'
-import { openChannel } from '../../parasSudoWrapper'
-
-export interface FinalOpenChannelBuilder {
-  build(): Extrinsic
-}
+import { TNode } from '../../../types'
+import { openChannel, openChannelSerializedApiCall } from '../../parasSudoWrapper'
+import { FinalBuilder } from './Builder'
 
 export interface MaxMessageSizeOpenChannelBuilder {
-  maxMessageSize(size: number): FinalOpenChannelBuilder
+  maxMessageSize(size: number): FinalBuilder
 }
 
 export interface MaxSizeOpenChannelBuilder {
@@ -17,7 +14,7 @@ export interface MaxSizeOpenChannelBuilder {
 }
 
 class OpenChannelBuilder
-  implements MaxSizeOpenChannelBuilder, MaxMessageSizeOpenChannelBuilder, FinalOpenChannelBuilder
+  implements MaxSizeOpenChannelBuilder, MaxMessageSizeOpenChannelBuilder, FinalBuilder
 {
   private api: ApiPromise
   private from: TNode
@@ -48,6 +45,16 @@ class OpenChannelBuilder
 
   build() {
     return openChannel(this.api, this.from, this.to, this._maxSize, this._maxMessageSize)
+  }
+
+  buildSerializedApiCall() {
+    return openChannelSerializedApiCall(
+      this.api,
+      this.from,
+      this.to,
+      this._maxSize,
+      this._maxMessageSize
+    )
   }
 }
 

--- a/src/pallets/hrmp/channelsClose.ts
+++ b/src/pallets/hrmp/channelsClose.ts
@@ -1,8 +1,30 @@
-//Contains call formatting for closing HRMP channels functionality
+// Contains call formatting for closing HRMP channels functionality
 
 import type { ApiPromise } from '@polkadot/api'
-import { Extrinsic, TNode } from '../../types'
+import { Extrinsic, TNode, TSerializedApiCall } from '../../types'
 import { getParaId } from '../assets'
+
+const closeChannelInternal = (
+  api: ApiPromise,
+  origin: TNode,
+  inbound: number,
+  outbound: number,
+  serializedApiCallEnabled = false
+): Extrinsic | TSerializedApiCall => {
+  const module = 'hrmp'
+  const section = 'forceCleanHrmp'
+  const parameters = [getParaId(origin), inbound, outbound]
+
+  if (serializedApiCallEnabled) {
+    return {
+      module,
+      section,
+      parameters
+    }
+  }
+
+  return api.tx.sudo.sudo(api.tx[module][section](...parameters))
+}
 
 export function closeChannel(
   api: ApiPromise,
@@ -10,5 +32,14 @@ export function closeChannel(
   inbound: number,
   outbound: number
 ): Extrinsic {
-  return api.tx.sudo.sudo(api.tx.hrmp.forceCleanHrmp(getParaId(origin), inbound, outbound))
+  return closeChannelInternal(api, origin, inbound, outbound) as Extrinsic
+}
+
+export function closeChannelSerializedApiCall(
+  api: ApiPromise,
+  origin: TNode,
+  inbound: number,
+  outbound: number
+): TSerializedApiCall {
+  return closeChannelInternal(api, origin, inbound, outbound, true) as TSerializedApiCall
 }


### PR DESCRIPTION
Add an extra function for openChannel and closeChannel functionality that returns a serialized api call that can be later utilized when implemting an XCM-API.